### PR TITLE
基础格式错误类型

### DIFF
--- a/Syntax/SyntaxError.ml
+++ b/Syntax/SyntaxError.ml
@@ -1,11 +1,28 @@
-
 (** [src_span] is a region in some source file.
     Used to report error messages *)
 type src_span =
     { span_start : Lexing.position
     ; span_end   : Lexing.position }
 
+(* Tokens are string literals in the input, while labels are the name of a
+   collection of tokens. For example, ";" is a token while type is a label that
+   could represent any type *)
+type error_elem =
+    | Token of string
+    | Label of string
+    | EndOfInput
+
+let pp_error_elem fmt elem = match elem with
+    | Token str  -> Format.fprintf fmt "\"%s\"" str
+    | Label str  -> Format.fprintf fmt "%s" str
+    | EndOfInput -> Format.fprintf fmt "[end of input]"
+
+module ErrorElemSet = Set.Make(struct type t = error_elem let compare = compare end)
+
 type error =
+    | Basic      of { unexpected : error_elem option
+                    ; expecting  : ErrorElemSet.t
+                    ; message    : string option }
     | Unclosed   of string
     | Expecting  of string
     | Unexpected of string
@@ -23,10 +40,36 @@ let pp_span fmt span =
         (span.span_end.pos_cnum - span.span_end.pos_bol)
 
 
+let rec expecting_helper fmt exp_list =
+    let open Format in
+    match exp_list with
+    | []      -> ();
+    | e :: [] -> fprintf fmt " or"; pp_error_elem fmt e;
+    | e :: es -> fprintf fmt ", "; pp_error_elem fmt e; expecting_helper fmt es
+
+
 let pp_error fmt err =
     let open Format in
+    let open Option in
     match err with
-    | Unclosed   msg -> fprintf fmt "unclosed %s"   msg
-    | Expecting  msg -> fprintf fmt "expecting %s"  msg
-    | Unexpected msg -> fprintf fmt "unexpected %s" msg
-    | BadToken   msg -> fprintf fmt "bad token %s"  msg
+    | Basic {unexpected; expecting; message}
+        ->  (if is_some unexpected then
+                fprintf fmt "Unexpected ";
+                match unexpected with
+                | None       -> fprintf fmt ""
+                | Some token -> pp_error_elem fmt token;
+                fprintf fmt ".\n");
+            (if not (ErrorElemSet.is_empty expecting) then
+                fprintf fmt "Expecting ";
+                let exp_list = ErrorElemSet.elements expecting in
+                pp_error_elem fmt (List.hd exp_list);
+                expecting_helper fmt (List.tl exp_list);
+                fprintf fmt ".\n");
+            (match message with
+            | None   -> fprintf fmt ""
+            | Some m -> fprintf fmt "%s" m);
+            fprintf fmt "\n"
+    | Unclosed   msg -> fprintf fmt "Unclosed %s"   msg
+    | Expecting  msg -> fprintf fmt "Expecting %s"  msg
+    | Unexpected msg -> fprintf fmt "Unexpected %s" msg
+    | BadToken   msg -> fprintf fmt "Bad token %s"  msg


### PR DESCRIPTION
该类型包 optional Unexpected, Set Expecting, 以及 optional 自定义错误message
Unexpected和Expecting可以是token(e.g. "+")；label (e.g. operator)；end-of-input symbol ([end-of-input])
Lexing支持UTF-8：报错时会抓取整个codepoint而不是前8个bit（如果源代码中出现non-ASCII字符，报错时便可以完整显示）